### PR TITLE
Make gocmd compile even if GOPATH is not defined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 megacmd
 tests/t.json
 tests/junk
+config.mk

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,27 @@
+# Output executable name
+EXECUTABLE=megacmd
+
 # Configure a local GOPATH if it's not exported by the user
-export GOPATH?=$(CURDIR)/.gopath
+LOCAL_GOPATH=$(CURDIR)/.gopath
+
+# Override settings from user configuration (if available)
+-include config.mk
+
+# Export GOPATH if not found
+export GOPATH?=$(LOCAL_GOPATH)
 
 build:
 	go get github.com/t3rm1n4l/go-mega
 	go get github.com/t3rm1n4l/megacmd/client
 	go get github.com/t3rm1n4l/go-humanize
-	go build
+	go build -o $(EXECUTABLE)
 
-test:
-	./tests/run_tests.sh
+clean:
+	rm -rf $(LOCAL_GOPATH)
+	rm -f  $(EXECUTABLE)
+	rm -rf tests/junk
+	rm -f  tests/t.json
+
+test: build
+	./tests/run_tests.sh $(EXECUTABLE)
 

--- a/tests/environ.bash
+++ b/tests/environ.bash
@@ -1,7 +1,7 @@
 #/bin/bash
 
 # Setup environment
-export MEGACMD="../megacmd -conf=t.json -verbose=0"
+export MEGACMD="../$MEGACMD_NAME -conf=t.json -verbose=0"
 
 JUNK="junk"
 OUT="$JUNK/out.txt"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Description: Tests execution wrapper
+# $1 holds the megacmd executable name
 
 trap exit SIGINT
 
@@ -7,6 +8,8 @@ echo Setting up test env
 cd `dirname ${BASH_SOURCE[*]}`
 
 ./setup.sh
+
+export MEGACMD_NAME=$1
 
 for t in t_*.sh;
 do


### PR DESCRIPTION
This PR makes gocmd build system more flexible:
- It will build even if there's no GOPATH defined in the user's environment. The build system will silently create one nested inside the source folder.
- It allows for a custom executable name
- It allows for the above settings to be persisted inside config.mk (which is not tracked by git)
- Makes test target depend on build (so that you can just run make test)
- Adds a clean target to delete build artifacts

I've added a .gitignore file so that generated files do not appear as "untracked" in git status
