### PR TITLE
= Prevent megacmd stopping when syncing synced files

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -628,8 +628,9 @@ func (mc *MegaClient) Sync(src, dst string) error {
 		}
 		if mc.cfg.Verbose > 0 {
 			if err == EFILE_EXISTS {
-				file := path.Join(dst, spath.GetPath())
-				err = errors.New(fmt.Sprintf("%s - %s", file, EFILE_EXISTS))
+				err = nil;
+				//file := path.Join(dst, spath.GetPath())
+				//err = errors.New(fmt.Sprintf("%s - %s", file, EFILE_EXISTS))
 			}
 		}
 


### PR DESCRIPTION
If you try to sync a folder, the second time won't run since megacmd stops on each file that already exists.
