### PR TITLE
Added -skip-error option when syncing to ignore files that can't be read...

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,7 @@ type Config struct {
 	Recursive       bool
 	Force           bool
 	SkipSameSize    bool
+	SkipError       bool
 	Verbose         int
 }
 
@@ -584,7 +585,7 @@ func (mc *MegaClient) Sync(src, dst string) error {
 			paths = append(paths, getRemotePaths(mc.mega.FS, n, true)...)
 		}
 	} else {
-		paths, err = getLocalPaths(src)
+		paths, err = getLocalPaths(src, mc.cfg.SkipError)
 		if err != nil {
 			return err
 		}

--- a/client/utils.go
+++ b/client/utils.go
@@ -52,14 +52,19 @@ func getRemotePaths(fs *mega.MegaFS, n *mega.Node, recursive bool) []Path {
 	return paths
 }
 
-func getLocalPaths(root string) ([]Path, error) {
+func getLocalPaths(root string, skiperror bool) ([]Path, error) {
 	var paths []Path
 
 	walker := func(p string, info os.FileInfo, err error) error {
 		var x Path
 		p, _ = filepath.Rel(root, p)
+
 		if err != nil {
-			return err
+			if skiperror {
+				return nil
+			} else {
+				return err
+			}
 		}
 
 		if p == "." {

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 		recursive = flag.Bool("recursive", false, "Recursive listing")
 		force     = flag.Bool("force", false, "Force hard delete or overwrite")
 		skipsize  = flag.Bool("skip-same-size", false, "Skip copying of files with same size and path suffix")
+		skiperror = flag.Bool("skip-error", false, "Skip syncing of files that can't be read")
 	)
 
 	log.SetFlags(0)
@@ -97,6 +98,10 @@ func main() {
 
 	if *skipsize {
 		conf.SkipSameSize = true
+	}
+
+	if *skiperror {
+		conf.SkipError = true
 	}
 
 	go func() {


### PR DESCRIPTION
....

This is important when syncing your home directory since .gvfs files etc
are not readable and stop your home dir from being synced.